### PR TITLE
changed is.tsibble to is_tsibble

### DIFF
--- a/R/util_functions.R
+++ b/R/util_functions.R
@@ -309,14 +309,14 @@ zoo_to_ts <- function(zoo.obj){
 
 ts_split <- function(ts.obj, sample.out = NULL){
   
-  if (!stats::is.ts(ts.obj) && !tsibble::is.tsibble(ts.obj)) {
+  if (!stats::is.ts(ts.obj) && !tsibble::is_tsibble(ts.obj)) {
     stop("The 'ts.obj' is not a valid 'ts' or 'tsibble' object")
   }
   
   l <- train <- test <- split <- NULL
   if(stats::is.ts(ts.obj)){
   l <- base::length(ts.obj)
-  } else if(tsibble::is.tsibble(ts.obj)){
+  } else if(tsibble::is_tsibble(ts.obj)){
   l <- base::nrow(ts.obj)  
   }
   
@@ -341,7 +341,7 @@ ts_split <- function(ts.obj, sample.out = NULL){
     test <- stats::window(ts.obj, 
                           start = stats::time(ts.obj)[base::length(stats::time(ts.obj)) - h + 1], 
                           end = stats::time(ts.obj)[base::length(stats::time(ts.obj))])
-  )} else if(tsibble::is.tsibble(ts.obj)){
+  )} else if(tsibble::is_tsibble(ts.obj)){
     split <- base::list(train = ts.obj[1:(base::nrow(ts.obj) - h),],
                         test = ts.obj[(base::nrow(ts.obj) - h + 1):base::nrow(ts.obj), ])
   }


### PR DESCRIPTION
Hi Rami,

`is.tsibble()` has been deprecated for about a year. This PR tweaks `is.tsibble()` to `is_tsibble()`.